### PR TITLE
Use $(datadir) everywhere in patch

### DIFF
--- a/datadir.patch
+++ b/datadir.patch
@@ -12,4 +12,4 @@ diff -up paper-2/Makefile.am.datadir paper-2/Makefile.am
  
  uninstall-hook:
 -	test -e $(DESTDIR)/usr/share/icons/Paper && rm -rfv $(DESTDIR)/usr/share/icons/Paper
-+	test -e $(DESTDIR)$(datadir)/icons/Paper && rm -rfv $(DESTDIR)/usr/share/icons/Paper
++	test -e $(DESTDIR)$(datadir)/icons/Paper && rm -rfv $(DESTDIR)$(datadir)/icons/Paper


### PR DESCRIPTION
From what I see, there should be one more place to use $(datadir) in the patch.